### PR TITLE
Update tzdata package

### DIFF
--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -7,6 +7,28 @@
 
 ---
 
+- name: RedHat | Update tzdata.
+  sudo: yes
+  yum:
+    name: 'tzdata'
+    state: latest
+  when: ansible_os_family == 'RedHat'
+  tags:
+    - package
+    - ntp
+
+- name: Debian | Update tzdata.
+  sudo: yes
+  apt:
+    pkg: 'tzdata'
+    state: latest
+    update_cache: yes
+    cache_valid_time: 3600
+  when: ansible_os_family == 'Debian'
+  tags:
+    - package
+    - ntp
+
 - name: NTP | Debian | Install specific NTP version.
   sudo: yes
   apt:


### PR DESCRIPTION
Your role works fine, but time can be incorrect (+1 hour) if remote system has old tzdata package.
I thought that tzdata updating process is a part of that role responsibility

What fix does:
- update tzdata package to latest version

Tested on
CentOS 6 \ 7 (x64)
Debian 6 \ 7 (x64)

it doesn't work for Debian 6, because is not supported yet and tzdata is too old (official repos)
